### PR TITLE
Fix website problems

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -67,7 +67,7 @@ jobs:
 
   # Deployment job
   deploy:
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -67,7 +67,7 @@ jobs:
 
   # Deployment job
   deploy:
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/documentation/doxFiles/installation.md
+++ b/documentation/doxFiles/installation.md
@@ -1,7 +1,9 @@
+\page installation Installing MUQ
+
 # Installing MUQ
 
-This page provides step-by-step instructions for installing MUQ, including setting 
-up required dependencies, choosing which MUQ's features to enable, and testing your installation. 
+This page provides step-by-step instructions for installing MUQ, including setting
+up required dependencies, choosing which MUQ's features to enable, and testing your installation.
 
 Follow these steps carefully to ensure compatibility and successful setup.
 
@@ -11,7 +13,7 @@ Follow these steps carefully to ensure compatibility and successful setup.
 
 - **Operating System**: Linux or MacOS
 
-- **C++ Compiler**: A C++17-compatible compiler. MUQ is currently tested only with GNU 11. Compatibility with higher versions is not fully 
+- **C++ Compiler**: A C++17-compatible compiler. MUQ is currently tested only with GNU 11. Compatibility with higher versions is not fully
 guaranteed. If you happen to try and observe errors, please report them by creating new issues.
 
 - **Python**: Python 3.12 (matching the latest `python3-dev` version for Ubuntu 24.04).
@@ -22,12 +24,12 @@ guaranteed. If you happen to try and observe errors, please report them by creat
 
 ## MUQ Compile Groups
 
-MUQ contains several capabilities which can be enabled via what MUQ calls "compile groups". 
-Compile groups might have different dependency requirements, and each compile group possibly depends on other groups. 
+MUQ contains several capabilities which can be enabled via what MUQ calls "compile groups".
+Compile groups might have different dependency requirements, and each compile group possibly depends on other groups.
 
-They have the following advantages: 
+They have the following advantages:
 - they allow you to select specific functionalities you want to build/install
-- when you enable a target compile group, internally the build system automatically turns on the other groups that are needed, 
+- when you enable a target compile group, internally the build system automatically turns on the other groups that are needed,
 so that you don't have to know all their interdependencies.
 
 The following table shows the compile groups and which TPLs each group depends on.
@@ -59,7 +61,7 @@ The following table shows the compile groups and which TPLs each group depends o
 | `INFERENCE_FILTERING`             | EIGEN3, BOOST, STANMATH                                               |
 
 
-When building Python bindings, the following table shows the Python compile groups: 
+When building Python bindings, the following table shows the Python compile groups:
 
 | Compile Group                     | Dependencies                                            |
 |-----------------------------------|---------------------------------------------------------|
@@ -74,10 +76,10 @@ When building Python bindings, the following table shows the Python compile grou
 
 **Does this mean you have to manually select a compile group every time you build MUQ?**
 
-No, you don't. Compile groups can be seen as an "expert mode" feature, since they provide a 
-conveniente way to have finer-grained control on what you enable, build and install. 
-If you want to avoid this, MUQ provides "default compile groups", namely groups that are enabled by default. 
-This can be done using the `-DMUQ_ENABLEGROUP_DEFAULT=ON` CMake argument when configuring MUQ. 
+No, you don't. Compile groups can be seen as an "expert mode" feature, since they provide a
+convenient way to have finer-grained control on what you enable, build and install.
+If you want to avoid this, MUQ provides "default compile groups", namely groups that are enabled by default.
+This can be done using the `-DMUQ_ENABLEGROUP_DEFAULT=ON` CMake argument when configuring MUQ.
 This is shown further in the [Configuration Examples section](#configuration-examples).
 
 
@@ -108,14 +110,14 @@ To install these dependencies, you can either:
 
 - use a suitable package manager or build them from source individually, or
 
-- use the provided build script in [our other repository](https://github.com/NexGenAnalytics/MIT-MUQ-containers): 
+- use the provided build script in [our other repository](https://github.com/NexGenAnalytics/MIT-MUQ-containers):
 ```
 python build_tpls.py --wdir $PWD --with all
 ```
 where `--wdir` specifies a working directory of your choice (can be non-existent) and `--with` allows you to specify which TPLs to build.
 
-This script will fetch, build and install the selected TPLs, and will generate a `tpls_cache.txt` file inside the working directory 
-containing all necessary information to give to CMake in order to find the needed dependencies. 
+This script will fetch, build and install the selected TPLs, and will generate a `tpls_cache.txt` file inside the working directory
+containing all necessary information to give to CMake in order to find the needed dependencies.
 As example of how to use this file with CMake is shown in the next section.
 
 We highly recommend using the build script as MUQ is tested only with this build process.

--- a/examples/SamplingAlgorithms/MCMC/Example1_Gaussian/python/meta.yml
+++ b/examples/SamplingAlgorithms/MCMC/Example1_Gaussian/python/meta.yml
@@ -2,5 +2,5 @@
     file: GaussianSampling.ipynb
     tag: MCMC
     title: Simple MCMC
-    description: Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target densityl.
+    description: Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target density.
     doc_level: 4 # 1 for no description, 2 for minimal description, 3 for several descriptive cellss, 4 for very good documentation

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ MUQ is available on Linux and OSX as a conda package, docker image, or from sour
 conda install -c conda-forge muq
 ```
 
-For more installation options, check out the [installation guide](https://nexgenanalytics.github.io/MIT-MUQ/latest/muqinstall.html).
+For more installation options, check out the [installation guide](https://nexgenanalytics.github.io/MIT-MUQ/latest/installation.html).
 
 ## Getting Started
 
-MUQ is composed of several different modules, which work together to define and solve UQ problems. 
-Documentation for each of these modules is included with our doxygen-generated [API documentation](https://nexgenanalytics.github.io/MIT-MUQ/latest/index.html). 
+MUQ is composed of several different modules, which work together to define and solve UQ problems.
+Documentation for each of these modules is included with our doxygen-generated [API documentation](https://nexgenanalytics.github.io/MIT-MUQ/latest/index.html).
 Most applications will require using the [modeling module](https://nexgenanalytics.github.io/MIT-MUQ/latest/group__modeling.html) to define statistical models or interact with user-defined models. Learning the basics of this module is therefore a good place to start.
 
 #### Interested in forward UQ?

--- a/website/index.html
+++ b/website/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <title>HTML Meta Tag</title>
-      <meta http-equiv = "refresh" content = "0; url = source/_site/index.html" />
+      <meta http-equiv = "refresh" content = "0; url = index.html" />
    </head>
    <body>
       <p>Redirecting to the MUQ homepage</p>

--- a/website/source/_config.yml
+++ b/website/source/_config.yml
@@ -8,7 +8,7 @@ relative_links:
   enabled: true
   collections: true
 
-url: https://nexgenanalytics.github.io/MIT-MUQ/
+url: https://nexgenanalytics.github.io/MIT-MUQ
 
 collections:
   example_pages:

--- a/website/source/_example_pages/webExamples/SamplingAlgorithms/MCMC/Example1_Gaussian/python/GaussianSampling.html
+++ b/website/source/_example_pages/webExamples/SamplingAlgorithms/MCMC/Example1_Gaussian/python/GaussianSampling.html
@@ -1,13 +1,13 @@
 ---
 title: Simple MCMC
 layout: default
-description: Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target densityl.
+description: Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target density.
 language: python
 tag: MCMC
 doc_level: 4
 ---
 <h1><small class="text-muted">Example</small> </br> Simple MCMC<h1>
-<blockquote class="blockquote"><p class="mb-0">Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target densityl.</p></blockquote>
+<blockquote class="blockquote"><p class="mb-0">Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target density.</p></blockquote>
 </br>
 
 
@@ -157,8 +157,8 @@ classTK = (&quot;Kernel1.Method&quot;, &quot;MHKernel&quot;)  # name of the tran
 blockNamePD = (&quot;Kernel1.Proposal&quot;, &quot;MyProposal&quot;) # name of block defining the proposal distribution
 classP = (&quot;Kernel1.MyProposal.Method&quot;, &quot;MHProposal&quot;) # name of proposal class
 varianceMH = (&quot;Kernel1.MyProposal.ProposalVariance&quot;, 0.5) # variance of the isotropic MH proposal
-               
-# dictionary of sampling parameters               
+
+# dictionary of sampling parameters
 pt = dict([numMCMC, blockNameTK, classTK, blockNamePD, classP, varianceMH])
 </pre>
 
@@ -226,8 +226,8 @@ classTK = (&quot;Kernel1.Method&quot;, &quot;MHKernel&quot;)  # name of the tran
 blockNamePD = (&quot;Kernel1.Proposal&quot;, &quot;MyProposal&quot;) # name of block defining the proposal distribution
 classP = (&quot;Kernel1.MyProposal.Method&quot;, &quot;MHProposal&quot;) # name of proposal class
 varianceMH = (&quot;Kernel1.MyProposal.ProposalVariance&quot;, 0.5) # variance of the isotropic MH proposal
-               
-# dictionary of sampling parameters               
+
+# dictionary of sampling parameters
 pt = dict([numMCMC, blockNameTK, classTK, blockNamePD, classP, varianceMH])
 
 mcmc = ms.SingleChainMCMC(pt,problem)

--- a/website/source/examples.html
+++ b/website/source/examples.html
@@ -26,7 +26,7 @@ layout: default
 
   <p>
   All examples listed here are part of the MUQ source code.
-  Refer to the documentation for <a href="_site/latest/installation.html">installation instructions</a>.
+  Refer to the documentation for <a href="{{ site.url }}/{{ site.data.doxygen.dox_tag }}/installation.html">installation instructions</a>.
   </p>
 
 <div class="btn-group" role="group" aria-label="Tags">

--- a/website/source/examples.html
+++ b/website/source/examples.html
@@ -26,7 +26,7 @@ layout: default
 
   <p>
   All examples listed here are part of the MUQ source code.
-  Refer to the documentation for <a href="_site/latest/muqinstall.html">installation instructions</a>.
+  Refer to the documentation for <a href="_site/latest/installation.html">installation instructions</a>.
   </p>
 
 <div class="btn-group" role="group" aria-label="Tags">

--- a/website/source/index.html
+++ b/website/source/index.html
@@ -62,7 +62,7 @@ Our goal is to provide an easy-to-use framework for defining and solving UQ prob
   <h3>Get Started!</h3>
   <div class="col-sm-4">
     <div class="thumbnail">
-        <a href="{{ site.data.doxygen.dox_tag }}/muqinstall.html" class="">
+        <a href="{{ site.data.doxygen.dox_tag }}/installation.html" class="">
             <div class="caption">
                 <h4 align="center">Installation</h4>
             </div>

--- a/website/source/index.html
+++ b/website/source/index.html
@@ -62,7 +62,7 @@ Our goal is to provide an easy-to-use framework for defining and solving UQ prob
   <h3>Get Started!</h3>
   <div class="col-sm-4">
     <div class="thumbnail">
-        <a href="{{ site.data.doxygen.dox_tag }}/installation.html" class="">
+        <a href="{{ site.url }}/{{ site.data.doxygen.dox_tag }}/installation.html" class="">
             <div class="caption">
                 <h4 align="center">Installation</h4>
             </div>


### PR DESCRIPTION
# Main Webpage

- [x] Top links have extra `/`
- [x] "Installation guide" link in GitHub README is wrong
- [ ] Slack captcha doesn't work

### Get Started!

- [x] Installation button sends to the wrong link

## Examples

- [x] Installation instructions link broken
- [x] Simple MCMC Python: Introduces MUQ's MCMC capabilities using a random walk proposal on a Gaussian target density.
- [x] Extra `/` in links

# Documentation Site

- [x] Installation guide link broken everywhere
- [ ] Search box image is missing

# Misc

- [x] Fix: `https://nexgenanalytics.github.io/MIT-MUQ//latest/md_doxygen__prep_2documentation_2doxFiles_2installation.html` in "Does this mean you have to manually select a compile group every time you build MUQ?" section: Change "conveniente" to "convenient"
- [ ] Fix: `https://nexgenanalytics.github.io/MIT-MUQ//latest/infrastructure.html`: Replace "MUQ2" with the correct term
